### PR TITLE
add port check

### DIFF
--- a/git-dolly
+++ b/git-dolly
@@ -72,11 +72,14 @@ def get_repo_path(root, repo):
     '/usr/src/scm.com/x/y'
     """
     p = urlparse(repo)
+    global port           
     if p.netloc:
-        host, path = p.netloc, p.path
+        host, path, port = p.netloc, p.path, p.port
     else:
         host, path = repo.split(':', 1)
     host = host.split('@')[-1]
+    if port is not None:
+        host = host.split(':')[0]
     assert host and ':' not in host, 'unsupported url'
     dirname = os.path.dirname(path)
     basename = os.path.basename(path)


### PR DESCRIPTION
add test for port. e.g. gerrit: 
`git clone ssh://user@gerrit:29418/Parent/project`
urlparse already separates port component correctly.
Added global port because of error:
>UnboundLocalError: local variable 'port' referenced before assignment